### PR TITLE
Settings: Add helpers to access settings urls

### DIFF
--- a/env/index.ts
+++ b/env/index.ts
@@ -162,11 +162,25 @@ export async function getServer(
         '',
       )
     }
-    const result = await phpx/* php */`
+
+    // Extract lines to use namespace and put them at the top
+    let useNamespace = ''
+    let filteredCode = ''
+
+    for (const line of (code as string).split('\n')) {
+      if (line.trim().startsWith('use ')) {
+        useNamespace += line + '\n';
+      } else {
+        filteredCode += line + '\n'
+      }
+    }
+
+const result = await phpx/* php */`
+${useNamespace}
 include 'wp-load.php';
 echo json_encode((function() {
   try {
-    ${code as string}
+    ${filteredCode}
   } catch (Exception $e) {
     return [
       'error' => $e->getMessage()

--- a/plugin/settings/index.php
+++ b/plugin/settings/index.php
@@ -17,6 +17,30 @@ function get_plugin_settings($plugin) {
   ;
 }
 
+function get_settings_page_values($plugin) {
+
+  $is_multisite = is_multisite();
+  $url_base = $is_multisite
+    ? 'settings.php'
+    : 'options-general.php'
+  ;
+  $settings_page_slug = "{$plugin->name}-settings";
+  $url = "{$url_base}?page={$settings_page_slug}";
+  $settings_page_url = $is_multisite ? network_admin_url($url) : admin_url($url);
+
+  return [
+    'url_base' => $url_base,
+    'page_slug' => $settings_page_slug,
+    'page_url'=> $settings_page_url
+  ];
+}
+
+function get_settings_tab_url($plugin, $tab_slug) {
+  $tab_query = !empty($tab_slug) ? "&tab=$tab_slug" : '';
+  $settings_page_url = get_settings_page_values($plugin)['page_url'];
+  return "{$settings_page_url}{$tab_query}";
+}
+
 /**
  * Register plugin settings
  * 
@@ -36,20 +60,18 @@ function register_plugin_settings($plugin, $config) {
     framework\load_plugin_features( $plugin );
   }
 
-  $is_multisite = is_multisite();
-  $url_base = $is_multisite
-    ? 'settings.php'
-    : 'options-general.php'
-  ;
-  $settings_page_slug = "{$plugin->name}-settings";
-  $url = "{$url_base}?page={$settings_page_slug}";
-  $settings_page_url = $is_multisite ? network_admin_url($url) : admin_url($url);
+  [
+    'url_base' => $url_base,
+    'page_slug' => $settings_page_slug,
+    'page_url' => $settings_page_url
+  ] = get_settings_page_values($plugin);
 
   $plugin->settings = $config;
   if (isset($config['features'])) {
     $plugin->features = $config['features'];
   }
 
+  $is_multisite = is_multisite();
   $settings_key = framework\get_plugin_settings_key($plugin);
   $prefix = $plugin->setting_prefix ?? str_replace('-', '_', $name);
   $nonce_key = "{$prefix}_nonce";

--- a/plugin/tests/index.ts
+++ b/plugin/tests/index.ts
@@ -1,0 +1,54 @@
+import { test, is, ok, run } from 'testra'
+import { getServerWithFramework } from '../../tests/common.ts'
+
+export default run(async () => {
+  const { php, request, wpx } = await getServerWithFramework()
+
+  test('Plugin settings', async () => {
+    let result
+
+    const registerPlugin = `$plugin = tangible\\framework\\register_plugin([
+      'name' => 'example'
+    ]);`;
+
+    result = await wpx`
+      ${registerPlugin}
+      return $plugin;
+    `
+    is(true, typeof result==='object', `register_plugin() returns object`)
+    is(true, 'name' in result, `$plugin->name`)
+
+    result = await wpx`
+      ${registerPlugin}
+      return tangible\\framework\\get_plugin_settings_page_config( $plugin );
+    `
+    is(true, typeof result==='object', `get_plugin_settings_page_config() returns object`)
+    is(true, 'slug' in result, `settings page slug`)
+    is(true, 'url' in result, `settings page url`)
+    is(true, 'url_base' in result, `settings page url base`)
+
+    // Double the backslash to escape in JS template literal then PHP string
+    result = await wpx`return function_exists('tangible\\\\framework\\\\is_plugin_settings_page');`
+
+    is(true, result, `function is_plugin_settings_page() exists`)
+
+    result = await wpx`
+      ${registerPlugin}
+      return tangible\\framework\\is_plugin_settings_page($plugin);
+    `
+
+    is(false, result, `is not plugin settings page`)
+
+    result = await wpx`
+      use tangible\\framework;
+      ${registerPlugin}
+      global $pagenow;
+      $pagenow = framework\\get_plugin_settings_page_url_base($plugin);
+      $_GET['page'] = framework\\get_plugin_settings_page_slug($plugin);
+      return framework\\is_plugin_settings_page($plugin);
+    `
+
+    is(true, result, `is plugin settings page`)
+
+  })
+})

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,3 +1,15 @@
+import { getServer } from '../env/index.js'
+
+export async function getServerWithFramework() {
+  const server = await getServer({
+    phpVersion: process.env.PHP_VERSION || '8.2',
+    reset: true,
+  })
+  const { wpx } = server
+  await ensureFrameworkActivated({ wpx })
+  return server
+}
+
 // Activate Framework as plugin if needed
 export async function ensureFrameworkActivated({ wpx }) {
   return await wpx/* php */ `

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -112,6 +112,7 @@ require( tangible\\framework::$state->path . '/tests/basic-assertions.php' );`
 
   await import('../api/tests/index.ts')
   await import('../file-system/tests/index.ts')
+  await import('../plugin/tests/index.ts')
 
   test('Log', async () => {
     const log = (


### PR DESCRIPTION
Hi @eliot-akira!

This pull request makes the settings value more accessible by adding two functions:
- `framework\get_settings_page_values( $plugin )`
- `framework\get_settings_tab_url( $plugin, 'tab-name' )`