### PR TITLE
Settings: Checkbox - Remove line break between hidden input and checkbox

### DIFF
--- a/plugin/settings/checkbox.php
+++ b/plugin/settings/checkbox.php
@@ -29,10 +29,18 @@ function render_setting_field_checkbox($config) {
 
   if (empty($type) || $type === 'checkbox'): ?>
       <label>
-          <input type="hidden" name="<?php echo $name; ?>" value="<?php echo $checked ? 'true' : 'false'; ?>" autocomplete="off">
-          <input type="checkbox" value="true" autocomplete="off"
-              onclick="this.previousSibling.value=this.previousSibling.value==='true'?'false':'true'" 
-              <?php echo $checked ? 'checked' : ''; ?> />
+          <input
+            type="hidden"
+            name="<?php echo $name; ?>"
+            value="<?php echo $checked ? 'true' : 'false'; ?>"
+            autocomplete="off"
+          ><input
+            type="checkbox"
+            value="true"
+            autocomplete="off"
+            onclick="this.previousSibling.value=this.previousSibling.value==='true'?'false':'true'"
+            <?php echo $checked ? 'checked' : ''; ?>
+          />
           <?php echo esc_html($label); ?>
       </label>
     <?php elseif ($type === 'switch'): ?>


### PR DESCRIPTION
Hi @eliot-akira!

I ran into a small issue while using the `render_setting_field_checkbox` function, it seems that the hidden input value wasn't being updated according to the checkbox value

It appears that in my case, `this.previousSibling` (from [here](https://github.com/TangibleInc/framework/blob/304968f9b2a440748f2afcb2bb706ef9498610d5/plugin/settings/checkbox.php#L34)) was returning the previous line break instead of the hidden input:
<img width="1337" height="189" alt="image" src="https://github.com/user-attachments/assets/91f49963-a519-404a-a967-9c3a3f84c96e" />

I changed a bit the formatting to avoid having a line break, as it seems to be the easiest way to fix the issue:
<img width="1337" height="189" alt="image" src="https://github.com/user-attachments/assets/e9ae9cfa-feb8-4767-a60d-946b9ca4afb9" />
